### PR TITLE
Update Deprecated Actions. Bump update-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             - run: yarn lint
 
             - name: Attach KIELER VS Code Extension (no server)
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                   name: KIELER VS Code Extension (no server)
                   path: keith-vscode/keith-vscode.vsix


### PR DESCRIPTION
see https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/